### PR TITLE
Aggiustamento delle parti legacy

### DIFF
--- a/wikigram.rb
+++ b/wikigram.rb
@@ -10,9 +10,9 @@ require 'json'
 
 ## CONFIGURATION START ##
 token = 'INSERT_YOUR_BOT_TOKEN_HERE' # Telegram bot API token
-api_ep = 'https://wikigram.it/home/api.php' # Mediawiki API endpoint
+api_ep = 'https://wikigram.it/api.php' # Mediawiki API endpoint
 # api_ep = 'https://it.wikipedia.org/w/api.php' # Example: Wikipedia API endpoint
-page_uri = "#{api_ep[0..-8]}index.php/" # Base URL for pages
+page_uri = "#{api_ep[0..-8]}/" # Base URL for pages
 # page_uri = "#{api_ep[0..-10]}wiki/" # Example: URL pattern for Wikipedia
 ## CONFIGURATION END ##
 


### PR DESCRIPTION
Dopo un aggiornamento disposto da  @Lollofra, ora Wikigram funziona perfettamente senza la stringa */Home/index.php/*NOMEPAGINA. Basta utilizzare wikigram.it/NOMEPAGINA
